### PR TITLE
fixed issue with load css not loading the resolving the proper path

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,24 @@
-var loadStyleName = "bit-loader-css/loadstyle.js";
+const loadStylePath = require.resolve("bit-loader-css/loadstyle.js");
+const loadStyleName = "$bit-loader-css/loadstyle";
 
 var defaults = {
-  extensions: ["css"],
+  match: {
+    extensions: ["css"],
+    name: loadStyleName
+  },
+  resolve: function(meta) {
+    if (meta.name === loadStyleName) {
+      return {
+        path: loadStylePath
+      };
+    }
+  },
   dependency: function cssDependency(meta) {
-    return {
-      deps: [loadStyleName],
-      source: "require('" + loadStyleName + "')(" + JSON.stringify(meta.source) + ");"
-    };
+    if (meta.name !== loadStyleName) {
+      return {
+        source: "require('" + loadStyleName + "')(" + JSON.stringify(meta.source) + ");"
+      };
+    }
   }
 };
 


### PR DESCRIPTION
the is when injecting the load-css dependency the proper path was not being given to bit-loader to resolve the path. so this was causing module not found errors.  